### PR TITLE
Trim spaces so as not to be considered as zeroes

### DIFF
--- a/src/components/AnimatedDigit.tsx
+++ b/src/components/AnimatedDigit.tsx
@@ -103,7 +103,7 @@ export const AnimatedDigit: React.FC<AnimatedDigitProps> = ({
   numberTextProps,
   ...rest
 }) => {
-  const isNumeric = !isNaN(Number(value));
+  const isNumeric = value.trim() !== '' && !isNaN(Number(value));
   const animatedValue = useSharedValue(isNumeric ? Number(value) : 0);
   const animatedStyle = useAnimatedStyle(
     () => ({


### PR DESCRIPTION
Implement the same fix proposed on the original repository https://github.com/BouarourMohammed/react-native-animated-rolling-numbers/pull/15